### PR TITLE
[DreamOne/Two] Fix compile error (do_image_tar) Thank's @Captain

### DIFF
--- a/meta-dreambox/conf/machine/dreamone.conf
+++ b/meta-dreambox/conf/machine/dreamone.conf
@@ -46,6 +46,7 @@ IMAGE_CMD:tar:prepend = " \
     mkdir -p ${IMAGE_ROOTFS}/tmp; \
     mkdir -p ${IMAGE_ROOTFS}/var/lib/opkg/info; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}; \
+    mkbootimg --base 0 --kernel_offset 0x1080000 --second_offset 0x1000000 -o ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/${KERNEL_FILE} --kernel ${DEPLOY_DIR_IMAGE}/Image.gz --second ${DEPLOY_DIR_IMAGE}/${MACHINE}.dtb --board ${BOARD} --cmdline "logo=osd0,loaded,0x7f800000 vout=1080p60hz,enable hdmimode=1080p60hz fb_width=1280 fb_height=720  console=ttyS0,1000000 root=/dev/mmcblk0p7 rootwait rootfstype=ext4 no_console_suspend"; \
     echo ${DISTRO_NAME}-${DISTRO_VERSION}.${BUILD_VERSION} > ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/imageversion; \
     echo "To update with the webbrowser select rootfs.tar.bz2" > ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/${MACHINE}_READ.ME; \
     cd ${IMAGE_ROOTFS}; \

--- a/meta-dreambox/conf/machine/dreamtwo.conf
+++ b/meta-dreambox/conf/machine/dreamtwo.conf
@@ -45,6 +45,7 @@ IMAGE_CMD:tar:prepend = " \
     mkdir -p ${IMAGE_ROOTFS}/tmp; \
     mkdir -p ${IMAGE_ROOTFS}/var/lib/opkg/info; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}; \
+    mkbootimg --base 0 --kernel_offset 0x1080000 --second_offset 0x1000000 -o ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/${KERNEL_FILE} --kernel ${DEPLOY_DIR_IMAGE}/Image.gz --second ${DEPLOY_DIR_IMAGE}/${MACHINE}.dtb --board ${BOARD} --cmdline "logo=osd0,loaded,0x7f800000 vout=1080p60hz,enable hdmimode=1080p60hz fb_width=1280 fb_height=720  console=ttyS0,1000000 root=/dev/mmcblk0p7 rootwait rootfstype=ext4 no_console_suspend"; \
     echo ${DISTRO_NAME}-${DISTRO_VERSION}.${BUILD_VERSION} > ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/imageversion; \
     echo "To update with the webbrowser select rootfs.tar.bz2" > ${DEPLOY_DIR_IMAGE}/${IMAGEDIR}/${MACHINE}_READ.ME; \
     cd ${IMAGE_ROOTFS}; \

--- a/meta-openpli/conf/layer.conf
+++ b/meta-openpli/conf/layer.conf
@@ -24,7 +24,7 @@ INSANE_SKIP:${PN} += "already-stripped ldflags"
 WARN_QA:remove = "src-uri-bad buildpaths invalid-packageconfig"
 
 #Include glib-gettextize, subversion and msgfmt(gettext) to hosttools
-HOSTTOOLS += "glib-gettextize java svn msgfmt zip"
+HOSTTOOLS += "glib-gettextize msgfmt base64 curl java python python2 sshpass svn unzip whoami zip"
 
 LAYERSERIES_COMPAT_openpli-layer = "langdale"
 


### PR DESCRIPTION
Log data follows:
| DEBUG: Executing python function set_image_size
| DEBUG: 462768.800000 = 355976 * 1.300000
| DEBUG: 462768.800000 = max(462768.800000, 65536)[462768.800000] + 0
| DEBUG: 462769.000000 = int(462768.800000)
| DEBUG: 462769 = aligned(462769)
| DEBUG: returning 462769
| DEBUG: Python function set_image_size finished
| DEBUG: Executing shell function do_image_tar
| /usr/bin/env: ‘python’: No such file or directory
| WARNING: exit code 127 from a shell command.
