### PR TITLE
dreambox-enigma2-config: Add missing skin.xml file

### DIFF
--- a/meta-dreambox/recipes-bsp/dreambox-enigma2-config/LICENSE
+++ b/meta-dreambox/recipes-bsp/dreambox-enigma2-config/LICENSE
@@ -1,0 +1,13 @@
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                   Version 2, December 2004
+
+Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+Everyone is permitted to copy and distribute verbatim or modified
+copies of this license document, and changing it is allowed as long
+as the name is changed.
+
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+ 0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/meta-dreambox/recipes-bsp/dreambox-enigma2-config/dm8000/skin_box.xml
+++ b/meta-dreambox/recipes-bsp/dreambox-enigma2-config/dm8000/skin_box.xml
@@ -1,0 +1,3 @@
+<skin>
+	<margin id="1" left="3" right="3" />
+</skin>


### PR DESCRIPTION
ERROR: /home/hains/openpli-dreambox-oe-core/meta-dreambox/recipes-bsp/dreambox-enigma2-config.bb: Unable to get checksum for dreambox-enigma2-config SRC_URI entry skin_box.xml: file could not be found The following paths were searched: