### PR TITLE
Create linux-%.bbappend

### DIFF
--- a/meta-openpli/recipes-kernel/linux/linux-%.bbappend
+++ b/meta-openpli/recipes-kernel/linux/linux-%.bbappend
@@ -1,0 +1,7 @@
+PR .= ".1"
+
+kernel_do_install:append() {
+    if [ ! -e ${B}/modules.builtin.modinfo ] ; then
+        touch ${D}/${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo
+    fi
+}


### PR DESCRIPTION
linux hide depmod: WARNING: could not open modules.builtin.modinfo for linux < 5.2

https://github.com/oe-alliance/oe-alliance-core/commit/63363ba475857b264e6ba90bed70e42f04b92e28