### PR TITLE
Update rt8723ds_5.10.1.bb

### DIFF
--- a/meta-openpli/recipes-connectivity/realtek/rt8723ds_5.10.1.bb
+++ b/meta-openpli/recipes-connectivity/realtek/rt8723ds_5.10.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://ifcfg-wlan0;md5=a84acae65af4b2d44d5035aa9f63cd85"
 
 DEPENDS ="bc-native"
 
-SRC_URI = "git://github.com/edision-open/RTL8723DS_WiFi_linux.git;protocol=https"
+SRC_URI = "git://github.com/edision-open/RTL8723DS_WiFi_linux.git;protocol=https;branch=master"
 
 SRCREV = "94eef3f7cb762b7309824be6cd2b6af75ac80bbd"
 


### PR DESCRIPTION
WARNING: /media/sdc1/OpenPLi/develop/meta-openpli/recipes-connectivity/realtek/rt8723ds_5.10.1.bb: URL: git://github.com/edision-open/RTL8723DS_WiFi_linux.git;protocol=https does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.