### PR TITLE
[enigma2-plugin-skins-e2darkos] Extend patch with MessageBox compat fixes

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-e2darkos/patch-skin-to-more-compatible.patch
+++ b/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-e2darkos/patch-skin-to-more-compatible.patch
@@ -76,3 +76,33 @@ index bef326f..a8bf074 100644
  		</widget>
  		<widget addon="Pager" connection="streams" position="545,835" size="860,25" transparent="1" backgroundColor="background" />
  		<eLabel backgroundColor="red" position="535,239" size="4,35" zPosition="2" />
+@@ -1385,10 +1375,7 @@ try:
+ except:
+ 	loadLogo = None
+
+-if self.timerRunning:
+-	titleheight = 0
+-else:
+-	titleheight = 0
++titleheight = 0
+
+ self["title_sep"] = Label("")
+ self["title_sep"].GUIcreate(self.instance)
+@@ -1402,7 +1389,7 @@ if (75 + textsize[1]) &gt; 180:
+ 	wsizey = textsize[1] + 80 + 84
+ else:
+ 	wsizey = 180 + 96
+-lenlist = len(self.list)*45
++lenlist = (len(self.list) if self.list else 0)*45
+ if (lenlist &gt; 380):
+ 	lenlist = 380
+ if (180 &gt; wsizey):
+@@ -1412,7 +1399,7 @@ wsizey += lenlist + 25
+
+ if (420 &gt; wsizex):
+ 	wsizex = 420
+-listwidth = self.getListWidth() + 20
++listwidth = (self.getListWidth() + 20) if self.list and hasattr(self, "getListWidth") else 0
+ if (listwidth &gt; 1280):
+ 	listwidth = 1280
+ if (listwidth &gt; wsizex):


### PR DESCRIPTION
The E2-DarkOS skin ships a <screen name="MessageBox"> with an onLayoutFinish applet that calls into a long-removed MessageBox API:

  - self.timerRunning - replaced by self.timeout in current enigma2
  - len(self.list) without None-check - self.list is now None for non-YESNO MessageBoxes (TYPE_ERROR, TYPE_INFO, ...)
  - self.getListWidth() - method no longer exists

The result was a hard crash loop on dm900/dm920 the moment the user selected the DarkOS skin and enigma2 tried to open the first MessageBox during startup ("Software problem detected" BSoD, modal dialogs, ...). The legitimate fix lives in the skin, not in enigma2, because the renderer/applet API contract was intentionally simplified upstream and the rest of the codebase has moved on.

Add a third hunk to patch-skin-to-more-compatible.patch that:

- Collapses the dead `if self.timerRunning: titleheight = 0 else: titleheight = 0` block into a plain `titleheight = 0` (both branches were already identical, so behaviour is preserved).
- Guards `lenlist = len(self.list)*45` with a truthiness check so the applet survives MessageBoxes without a choice list.
- Guards `listwidth = self.getListWidth() + 20` with both a self.list check and a hasattr() probe so the applet degrades to listwidth=0 on enigma2 builds that have removed the helper.

Existing entryFont/valueFont addition and the stream-selection template rewrite from the original patch are left untouched.