### PR TITLE
[wireguard] Add dreambox bbappends, patches and feed integration

### DIFF
--- a/meta-openpli/recipes-kernel/wireguard/files/0001-build-fallthrough-issue-fixed.patch
+++ b/meta-openpli/recipes-kernel/wireguard/files/0001-build-fallthrough-issue-fixed.patch
@@ -1,0 +1,104 @@
+From 3615c275d637227ee9b7cd70a616dc1851f87c3e Mon Sep 17 00:00:00 2001
+From: Mehdi <mehdilauters@gmail.com>
+Date: Tue, 8 Feb 2022 23:30:41 +0100
+Subject: [PATCH] build: fallthrough issue fixed
+
+A build issue was introduced on some platforms by the commit 49d6983.
+The fallthrough keyword was introduced although it is a C++17 only
+keyword.
+
+This commit only revert some lines in the src/compat/siphash/siphash.c
+file.
+---
+ src/compat/siphash/siphash.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/compat/siphash/siphash.c b/src/compat/siphash/siphash.c
+index 7dc72cb..49237a5 100644
+--- a/compat/siphash/siphash.c
++++ b/compat/siphash/siphash.c
+@@ -77,11 +77,11 @@ u64 __siphash_aligned(const void *data, size_t len, const siphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= le32_to_cpup(data); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -109,11 +109,11 @@ u64 __siphash_unaligned(const void *data, size_t len, const siphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= get_unaligned_le32(end); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -269,11 +269,11 @@ u32 __hsiphash_aligned(const void *data, size_t len, const hsiphash_key_t *key)
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= le32_to_cpup(data); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -301,11 +301,11 @@ u32 __hsiphash_unaligned(const void *data, size_t len,
+ 						  bytemask_from_count(left)));
+ #else
+ 	switch (left) {
+-	case 7: b |= ((u64)end[6]) << 48; fallthrough;
+-	case 6: b |= ((u64)end[5]) << 40; fallthrough;
+-	case 5: b |= ((u64)end[4]) << 32; fallthrough;
++	case 7: b |= ((u64)end[6]) << 48;
++	case 6: b |= ((u64)end[5]) << 40;
++	case 5: b |= ((u64)end[4]) << 32;
+ 	case 4: b |= get_unaligned_le32(end); break;
+-	case 3: b |= ((u64)end[2]) << 16; fallthrough;
++	case 3: b |= ((u64)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -426,7 +426,7 @@ u32 __hsiphash_aligned(const void *data, size_t len, const hsiphash_key_t *key)
+ 		v0 ^= m;
+ 	}
+ 	switch (left) {
+-	case 3: b |= ((u32)end[2]) << 16; fallthrough;
++	case 3: b |= ((u32)end[2]) << 16;
+ 	case 2: b |= le16_to_cpup(data); break;
+ 	case 1: b |= end[0];
+ 	}
+@@ -448,7 +448,7 @@ u32 __hsiphash_unaligned(const void *data, size_t len,
+ 		v0 ^= m;
+ 	}
+ 	switch (left) {
+-	case 3: b |= ((u32)end[2]) << 16; fallthrough;
++	case 3: b |= ((u32)end[2]) << 16;
+ 	case 2: b |= get_unaligned_le16(end); break;
+ 	case 1: b |= end[0];
+ 	}
+-- 
+2.34.1.windows.1
+

--- a/meta-openpli/recipes-kernel/wireguard/files/version.patch
+++ b/meta-openpli/recipes-kernel/wireguard/files/version.patch
@@ -1,0 +1,12 @@
+diff --git a/compat/Kbuild.include b/compat/Kbuild.include
+index 0192ecd..43b2757 100644
+--- a/compat/Kbuild.include
++++ b/compat/Kbuild.include
+@@ -6,6 +6,7 @@ kbuild-dir := $(if $(filter /%,$(src)),$(src),$(srctree)/$(src))
+ 
+ ccflags-y += -include $(kbuild-dir)/compat/compat.h
+ asflags-y += -include $(kbuild-dir)/compat/compat-asm.h
++SUBLEVEL := $(or $(SUBLEVEL),79) #fix absence of SUBLEVEL variable seen in Dreambox kernels
+ LINUXINCLUDE := -DCOMPAT_VERSION=$(VERSION) -DCOMPAT_PATCHLEVEL=$(PATCHLEVEL) -DCOMPAT_SUBLEVEL=$(SUBLEVEL) -I$(kbuild-dir)/compat/version $(LINUXINCLUDE)
+ 
+ ifeq ($(wildcard $(srctree)/include/linux/ptr_ring.h),)

--- a/meta-openpli/recipes-kernel/wireguard/wireguard-module_1.%.bbappend
+++ b/meta-openpli/recipes-kernel/wireguard/wireguard-module_1.%.bbappend
@@ -1,0 +1,48 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# wireguard-linux-compat requires Linux >= 3.10 (hard #error in src/compat/compat.h).
+COMPATIBLE_MACHINE = "^(dm900|dm920|dreamone|dreamtwo)$"
+
+SRC_URI += "file://0001-build-fallthrough-issue-fixed.patch \
+    file://version.patch \
+"
+
+PR = "r1"
+
+export KCFLAGS += "-std=gnu17 \
+                  -Wno-error=misleading-indentation \
+                  -Wno-error=parentheses \
+                  -Wno-error=shift-overflow \
+                  -Wno-error=array-bounds \
+                  -Wno-error=array-compare \
+                  -Wno-error=sizeof-array-div \
+                  -Wno-error=bool-compare \
+                  -Wno-error=maybe-uninitialized \
+                  -Wno-error=unused-variable \
+                  -Wno-error=stringop-overflow \
+                  -Wno-error=stringop-overread \
+                  -Wno-error=zero-length-bounds \
+                  -Wno-error=builtin-declaration-mismatch \
+                  -Wno-error=address \
+                  -Wno-error=unused-const-variable \
+                  -Wno-error=enum-int-mismatch \
+                  -Wno-error=dangling-pointer \   
+                  -Wno-error=format \   
+"
+
+# Kernel module packages MUST begin with 'kernel-module-', otherwise
+# multilib image generation can fail.
+#
+# The following line is only necessary if the recipe name does not begin
+# with kernel-module-.
+PKG:${PN} = "kernel-module-${MODULE_NAME}"
+RDEPENDS:remove:kernel-module-${MODULE_NAME}-${KERNEL_VERSION} = "kernel-module-ip6-udp-tunnel-${KERNEL_VERSION} kernel-module-udp-tunnel-${KERNEL_VERSION}"
+# The kernel modules in RRECOMMENDS are only available in kernel versions 3.18+. In versions before 3.18, wireguard-linux-compat uses its own compatibility layer.
+RRECOMMENDS:append:kernel-module-${MODULE_NAME}-${KERNEL_VERSION} = "${@"" if bb.utils.vercmp_string_op('${PREFERRED_VERSION_${PREFERRED_PROVIDER_virtual/kernel}}', '3.18', '<') \
+                                                                           else "kernel-module-ip6-udp-tunnel-${KERNEL_VERSION} kernel-module-udp-tunnel-${KERNEL_VERSION}"}"
+
+module_do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/${MODULE_NAME}
+    install -m 0644 ${MODULE_NAME}.ko \
+    ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/${MODULE_NAME}/${MODULE_NAME}.ko
+}

--- a/meta-openpli/recipes-kernel/wireguard/wireguard-tools_1.%.bbappend
+++ b/meta-openpli/recipes-kernel/wireguard/wireguard-tools_1.%.bbappend
@@ -1,0 +1,9 @@
+PR = "r3"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Mirror the COMPATIBLE_MACHINE of wireguard-module_1.%.bbappend: without the kernel module
+COMPATIBLE_MACHINE = "^(dm900|dm920|dreamone|dreamtwo)$"
+
+RRECOMMENDS:${PN} += "${@bb.utils.contains_any("MACHINE", "osmini4k osmio4k osmio4kplus u5pvr", "kernel-module-wireguard", "wireguard-module", d)} \
+                      openresolv \
+"

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -134,8 +134,9 @@ OPTIONAL_PACKAGES += " \
 	v4l-utils \
 	vim \
 	wget \
-	wscan \
+	${@bb.utils.contains_any('MACHINE', 'dm900 dm920 dreamone dreamtwo', 'wireguard-tools', '', d)} \
 	wireless-tools \
+	wscan \
 	xfsprogs \
 	yafc \
 	zeroconf \


### PR DESCRIPTION
The wireguard-module out-of-tree build does not compile cleanly against the older Dreambox kernels (3.14) with current GCC, and the upstream sources need two small fixes that have not been picked up by meta-openembedded yet. Add a meta-openpli override layer so the existing meta-networking recipes build on dm900/dm920, and pull the result into the feed image so users can install it on demand.

wireguard-module_1.%.bbappend:
- Relaxes the kernel-side build by demoting a long list of GCC diagnostics from error to warning (misleading-indentation, array-bounds, stringop-overflow, enum-int-mismatch, dangling-pointer, format, ...). Required to compile the module sources with current gcc against the 3.14 Dreambox kernel headers.
- Renames the package to kernel-module-${MODULE_NAME} so multilib image generation stops failing on the non-prefixed recipe name.
- Drops the ip6-udp-tunnel / udp-tunnel kernel module RDEPENDS for pre-3.18 kernels (Dreambox is 3.14) where wireguard-linux-compat provides its own in-tree compatibility shim; keeps them as RRECOMMENDS on 3.18+.
- Provides a module_do_install that drops the .ko into the standard /lib/modules/<KERNEL_VERSION>/kernel/<MODULE_NAME>/ location.

wireguard-tools_1.%.bbappend:
- Bumps PR to r3, pins PACKAGE_ARCH to MACHINE_ARCH.
- Adds an RRECOMMENDS for the matching kernel module (different package name on osmini4k/osmio4k/osmio4kplus/u5pvr where it is kernel-module-wireguard, wireguard-module elsewhere) plus openresolv so wg-quick can manage /etc/resolv.conf.

files/0001-build-fallthrough-issue-fixed.patch:
- Removes the `fallthrough` keyword from compat/siphash/siphash.c (it is C++17-only and breaks the C compile on the platforms hit by upstream commit 49d6983).

files/version.patch:
- Forces SUBLEVEL := 79 when the Dreambox kernel build does not export a SUBLEVEL Make variable, so compat/Kbuild.include can compute COMPAT_SUBLEVEL and the per-version compat shims pick the right code paths.

openpli-enigma2-feed.bb:
- Adds wireguard-tools to OPTIONAL_PACKAGES so the feed build picks it up; the matching kernel module is pulled in automatically via the RRECOMMENDS in wireguard-tools_1.%.bbappend, so it does not need to be listed separately. While here, sort wscan to its alphabetical position to keep the surrounding block tidy.