### PR TITLE
[stb-kodi] Bump bundled groovy from 4.0.23 to 4.0.29

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/stb-kodi_22.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/stb-kodi_22.bb
@@ -82,11 +82,11 @@ PATCHTOOL = "git"
 PR = "r3"
 
 PV = "22.0+gitr"
-PV_groovy = "4.0.23"
+PV_groovy = "4.0.29"
 PV_commons-lang3 = "3.20.0"
 PV_commons-text = "1.15.0"
 
-SRC_URI[groovy.sha256sum] = "7089dd7a1e84adc814d616f5ec2f7d7dac2044a0a0457f3341b3b92d30204229"
+SRC_URI[groovy.sha256sum] = "4a42d976370c6ab373a35ec602440a8a780a7715d55e4117b3028864a247878a"
 SRC_URI[commons-lang.sha256sum] = "a77875dbc8b7b687e49d914cf00cf7237a548f4163c2a64565b3da999d8b024f"
 SRC_URI[commons-text.sha256sum] = "af36d019def06a31b4d5accf60b13c4de817ec8569af1ffb410eb5ab16b39721"
 SRC_URI[libdvdcss.sha256sum] = "f38c4a4e7a4f4da6d8e83b8852489aa3bb6588a915dc41f5ee89d9aad305a06e"


### PR DESCRIPTION
Building stb-kodi against a host JDK 25 (OpenJDK 25 early-access) makes the recipe's bundled Groovy 4.0.23 explode during code generation:

    BUG! exception in phase 'semantic analysis' in source unit
      '.../tools/codegenerator/Generator.groovy'
    Unsupported class file major version 69

Class file major version 69 is Java 25. Groovy 4.0.23 only understands up to Java 23 (major 67), so as soon as the host toolchain hands it a Java 25 .class on the classpath, Generator.groovy aborts in the semantic analysis phase and `make` fails near 100%.

Groovy 4.0.29 (current 4.0.x patch release) is documented to support JDK 8-25 and reads major 69 fine.

4.x is API-compatible within the major line; 4.0.29 is a pure patch release with no semantics changes relevant to kodi's build-time use. Hosts on older JDKs (17, 21) keep working - the new Groovy supports JDK 8 upwards.