### PR TITLE
[enigma2-plugin-skins-e2darkos] Shrink UpdatePluginMenu list so it no longer collides with the description

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-e2darkos/patch-skin-to-more-compatible.patch
+++ b/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-e2darkos/patch-skin-to-more-compatible.patch
@@ -106,3 +106,16 @@ index bef326f..a8bf074 100644
  if (listwidth &gt; 1280):
  	listwidth = 1280
  if (listwidth &gt; wsizex):
+diff --git a/usr/share/enigma2/E2-DarkOS/skin_openpli.xml b/usr/share/enigma2/E2-DarkOS/skin_openpli.xml
+index feca669..feca66a 100644
+--- a/usr/share/enigma2/E2-DarkOS/skin_openpli.xml
++++ b/usr/share/enigma2/E2-DarkOS/skin_openpli.xml
+@@ -38,7 +38,7 @@
+ 	<!-- Plugin manager -->
+ 	<screen name="UpdatePluginMenu" position="fill" title="Software management" flags="wfNoBorder" backgroundColor="transparent">
+ 		<panel name="Screen_Menu1" />
+-		<widget source="menu" render="Listbox" position="396,200" size="1110,900" zPosition="3" transparent="1" enableWrapAround="1" scrollbarMode="showNever">
++		<widget source="menu" render="Listbox" position="396,200" size="1110,460" zPosition="3" transparent="1" enableWrapAround="1" scrollbarMode="showOnDemand">
+ 			<convert type="TemplatedMultiContent">
+ 			{"template": [
+ 					MultiContentEntryText(pos = (75,15),size = (1035,45),flags = RT_HALIGN_LEFT|RT_VALIGN_CENTER,text = 1),# index 0 is the MenuText,


### PR DESCRIPTION
The Software-management screen (UpdatePluginMenu) in skin_openpli.xml positions the menu list at y=200 with height=900 and a second listbox that renders the entry description ("Backup your running image to HDD or USB.", etc.) at y=680 height=240. The two rectangles overlap from y=680 down to y=920.

On OpenPLi this is invisible because the Python side only fills 5 entries (Manage extensions, Software update, Backup system settings, Restore system settings, Install local extension) - the list items end well above y=680.

SoftwareManager/plugin.py adds three image-tools entries on top (Backup Image, Flash Online, MultiBoot Manager) - see Lines 142-145. That pushes the menu down to roughly y=875, so items 4-8 land right behind the grey description box, producing the visible overlap on the DarkOS skin.

The two listboxes are part of the upstream DarkOS skin layout and we do not want to touch the description placement (it has to sit there for the rest of the design to work), so just clamp the menu list to size="1110,460" (ends at y=660, 20 px above the description) and flip scrollbarMode from "showNever" to "showOnDemand" so longer menus stay reachable via scroll.

Effect:
- 5-entry menu still fits without a scrollbar - 5*75 = 375 px which is well below the new 460 px limit.
- 9-entry menu now scrolls cleanly inside the box instead of bleeding into the description.
- Description widget at (396,680) stays exactly where it was; no other geometry is touched.